### PR TITLE
Add accounts management tab

### DIFF
--- a/src/frontend/components/add_account_modal.py
+++ b/src/frontend/components/add_account_modal.py
@@ -1,0 +1,50 @@
+import datetime
+from dash import html, dcc
+import dash_bootstrap_components as dbc
+from utils.theme import COLORS, INPUT_STYLE, BUTTON_PRIMARY_STYLE, BUTTON_SECONDARY_STYLE
+
+
+def create_add_account_modal():
+    """Modal dialog with form for adding an account."""
+    modal = dbc.Modal(
+        [
+            dbc.ModalHeader(dbc.ModalTitle("Add Account")),
+            dbc.ModalBody([
+                html.Div([
+                    html.Label("Name", htmlFor="account-name-input", className="text-primary"),
+                    dbc.Input(id="account-name-input", type="text", placeholder="Account name", className="form-input mb-10"),
+                ]),
+                html.Div([
+                    html.Label("Type", htmlFor="account-type-input", className="text-primary"),
+                    dbc.Input(id="account-type-input", type="text", placeholder="Account type", className="form-input mb-10"),
+                ]),
+                html.Div([
+                    html.Label("Starting Balance", htmlFor="account-balance-input", className="text-primary"),
+                    dbc.Input(id="account-balance-input", type="number", placeholder="0", className="form-input mb-10"),
+                ]),
+                html.Div([
+                    html.Label("Currency", htmlFor="account-currency-input", className="text-primary"),
+                    dbc.Input(id="account-currency-input", type="text", placeholder="Currency", className="form-input mb-10"),
+                ]),
+            ]),
+            dbc.ModalFooter([
+                dbc.Button("Add", id="submit-account-button", n_clicks=0, className="btn-primary width-120"),
+                dbc.Button("Close", id="close-add-account-modal", n_clicks=0, className="btn-secondary width-120"),
+            ])
+        ],
+        id="add-account-modal",
+        is_open=False,
+        backdrop=True,
+        size="lg",
+    )
+
+    return dcc.Loading(
+        modal,
+        type="default",
+        style={
+            'width': '100%',
+            'marginTop': '65rem',
+            'position': 'fixed',
+            'zIndex': 2000
+        }
+    )

--- a/src/frontend/components/edit_account_modal.py
+++ b/src/frontend/components/edit_account_modal.py
@@ -1,0 +1,52 @@
+import datetime
+from dash import html, dcc
+import dash_bootstrap_components as dbc
+from utils.theme import COLORS, INPUT_STYLE, BUTTON_PRIMARY_STYLE, BUTTON_SECONDARY_STYLE
+
+
+def create_edit_account_modal():
+    """Modal dialog for editing or deleting an account."""
+    modal = dbc.Modal(
+        [
+            dcc.Store(id="edit-account-id"),
+            dbc.ModalHeader(dbc.ModalTitle("Edit Account")),
+            dbc.ModalBody([
+                html.Div([
+                    html.Label("Name", htmlFor="edit-account-name-input", className="text-primary"),
+                    dbc.Input(id="edit-account-name-input", type="text", placeholder="Account name", className="form-input mb-10"),
+                ]),
+                html.Div([
+                    html.Label("Type", htmlFor="edit-account-type-input", className="text-primary"),
+                    dbc.Input(id="edit-account-type-input", type="text", placeholder="Account type", className="form-input mb-10"),
+                ]),
+                html.Div([
+                    html.Label("Starting Balance", htmlFor="edit-account-balance-input", className="text-primary"),
+                    dbc.Input(id="edit-account-balance-input", type="number", placeholder="0", className="form-input mb-10"),
+                ]),
+                html.Div([
+                    html.Label("Currency", htmlFor="edit-account-currency-input", className="text-primary"),
+                    dbc.Input(id="edit-account-currency-input", type="text", placeholder="Currency", className="form-input mb-10"),
+                ]),
+            ]),
+            dbc.ModalFooter([
+                dbc.Button("Update", id="update-account-button", n_clicks=0, className="btn-primary width-120"),
+                dbc.Button("Delete", id="delete-account-button", n_clicks=0, className="btn-danger width-120"),
+                dbc.Button("Close", id="close-edit-account-modal", n_clicks=0, className="btn-secondary width-120"),
+            ])
+        ],
+        id="edit-account-modal",
+        is_open=False,
+        backdrop=True,
+        size="lg",
+    )
+
+    return dcc.Loading(
+        modal,
+        type="default",
+        style={
+            'width': '100%',
+            'marginTop': '30rem',
+            'position': 'fixed',
+            'zIndex': 2000
+        }
+    )

--- a/src/frontend/components/navigation.py
+++ b/src/frontend/components/navigation.py
@@ -36,6 +36,16 @@ def create_navigation_bar(active_tab='overview'):
         ], className=None)
     )
 
+    nav_items.append(
+        html.Li([
+            html.Button(
+                "Add Account",
+                id="open-add-account-button",
+                className='nav-button add-transaction-button mr-20'
+            )
+        ], className=None)
+    )
+
     # Add logout button as last item
     nav_items.append(
         html.Li([

--- a/src/frontend/helper/requests/accounts_request.py
+++ b/src/frontend/helper/requests/accounts_request.py
@@ -18,3 +18,61 @@ def get_accounts(access_token: str, account_id: str | None = None) -> dict:
     response = requests.get(url, headers=headers, params=params)
     response.raise_for_status()
     return response.json()
+
+
+def create_account(access_token: str, payload: dict) -> dict:
+    """Create a new account via POST request."""
+
+    url = f"{BACKEND_URL}/accounts/"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "X-API-KEY": BACKEND_API_KEY,
+        "Content-Type": "application/json",
+    }
+    try:
+        response = requests.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+    except Exception as e:
+        return {"success": False, "message": f"Error creating account: {e}"}
+
+    if response.status_code != 201:
+        error_message = response.json().get("detail", "Unknown error")
+        return {"success": False, "message": f"Failed to add account: {error_message}"}
+
+    return {"success": True, "message": "Account added"}
+
+
+def update_account(access_token: str, account_id: str, payload: dict) -> dict:
+    """Update an existing account via PUT request."""
+
+    url = f"{BACKEND_URL}/accounts/{account_id}"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "X-API-KEY": BACKEND_API_KEY,
+        "Content-Type": "application/json",
+    }
+    try:
+        response = requests.put(url, headers=headers, json=payload)
+        response.raise_for_status()
+    except Exception as e:
+        return {"success": False, "message": f"Error updating account: {e}"}
+
+    return {"success": True, "message": "Account updated"}
+
+
+def delete_account(access_token: str, account_id: str) -> dict:
+    """Delete an account via DELETE request."""
+
+    url = f"{BACKEND_URL}/accounts/{account_id}"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "X-API-KEY": BACKEND_API_KEY,
+    }
+    try:
+        response = requests.delete(url, headers=headers)
+        response.raise_for_status()
+    except Exception as e:
+        return {"success": False, "message": f"Error deleting account: {e}"}
+
+    return {"success": True, "message": "Account deleted"}
+

--- a/src/frontend/pages/tabs/accounts.py
+++ b/src/frontend/pages/tabs/accounts.py
@@ -1,0 +1,204 @@
+from dash import html, dcc, Input, Output, State, callback, dash_table
+import dash_bootstrap_components as dbc
+from utils.theme import COLORS, LOADING_STYLE
+from helper.requests.accounts_request import (
+    get_accounts,
+    update_account as request_update_account,
+    delete_account as request_delete_account,
+)
+from components.edit_account_modal import create_edit_account_modal
+import dash
+
+LIMIT = 50
+
+def create_accounts_tab():
+    """Create the accounts tab content"""
+
+    content_style = {
+        'backgroundColor': COLORS['background_primary'],
+        'padding': '24px',
+        'margin': '0',
+        'minHeight': '100%',
+        'width': '100%'
+    }
+
+    return html.Div(
+        id='accounts-tab-content',
+        style=content_style,
+        children=[
+            html.H2('Accounts', style={'color': COLORS['text_primary'], 'marginBottom': '20px'}),
+            dcc.Store(id='accounts-offset-store', data={'offset': 0}),
+            dcc.Store(id='accounts-refresh-store', data={'refresh': 0}),
+            dbc.Row([
+                dbc.Col(dbc.Button('Previous', id='accounts-prev-btn', color='secondary', className='me-2'), width='auto'),
+                dbc.Col(dbc.Button('Next', id='accounts-next-btn', color='secondary'), width='auto'),
+                dbc.Col(html.Div(id='accounts-page-info', style={'alignSelf': 'center', 'marginLeft': '10px'}), width='auto')
+            ], className='mb-3'),
+            dcc.Loading(
+                dash_table.DataTable(
+                id='accounts-table',
+                data=[],
+                columns=[
+                    {'name': 'id', 'id': 'id'},
+                    {'name': 'name', 'id': 'name'},
+                    {'name': 'type', 'id': 'type'},
+                    {'name': 'starting_balance', 'id': 'starting_balance'},
+                    {'name': 'currency', 'id': 'currency'},
+                    {'name': 'created_at', 'id': 'created_at'}
+                ],
+                row_selectable='single',
+                style_cell={
+                    'textAlign': 'left',
+                    'backgroundColor': COLORS['background_secondary'],
+                    'color': COLORS['text_primary'],
+                    'border': f'1px solid {COLORS["text_secondary"]}',
+                    'padding': '8px'
+                },
+                style_header={
+                    'backgroundColor': COLORS['text_secondary'],
+                    'color': COLORS['background_primary'],
+                    'fontWeight': 'bold'
+                },
+                page_action='none'
+            ), style=LOADING_STYLE),
+            create_edit_account_modal(),
+        ]
+    )
+
+
+@callback(
+    Output('accounts-offset-store', 'data', allow_duplicate=True),
+    Input('accounts-prev-btn', 'n_clicks'),
+    State('accounts-offset-store', 'data'),
+    prevent_initial_call=True
+)
+def prev_page(n_clicks, data):
+    if n_clicks is None:
+        return dash.no_update
+    offset = max(0, (data or {}).get('offset', 0) - LIMIT)
+    return {'offset': offset}
+
+
+@callback(
+    Output('accounts-offset-store', 'data', allow_duplicate=True),
+    Input('accounts-next-btn', 'n_clicks'),
+    State('accounts-offset-store', 'data'),
+    prevent_initial_call=True
+)
+def next_page(n_clicks, data):
+    if n_clicks is None:
+        return dash.no_update
+    offset = (data or {}).get('offset', 0) + LIMIT
+    return {'offset': offset}
+
+
+@callback(
+    [Output('accounts-table', 'data'),
+     Output('accounts-page-info', 'children')],
+    [Input('navigation-store', 'data'),
+     Input('accounts-offset-store', 'data'),
+     Input('accounts-refresh-store', 'data')],
+    State('token-store', 'data')
+)
+def update_accounts(nav_data, offset_data, _refresh, token_store):
+    if nav_data.get('active_tab') != 'accounts':
+        return [], ''
+    if not token_store or not token_store.get('access_token'):
+        return [], ''
+
+    offset = (offset_data or {}).get('offset', 0)
+    try:
+        data = get_accounts(token_store['access_token'])
+        items = data.get('data', [])
+        sliced = items[offset: offset + LIMIT]
+        info = f"Showing {offset + 1}-{offset + len(sliced)}"
+        return sliced, info
+    except Exception:
+        return [], 'Failed to load accounts'
+
+
+@callback(
+    [
+        Output('edit-account-modal', 'is_open'),
+        Output('edit-account-id', 'data'),
+        Output('edit-account-name-input', 'value'),
+        Output('edit-account-type-input', 'value'),
+        Output('edit-account-balance-input', 'value'),
+        Output('edit-account-currency-input', 'value'),
+    ],
+    Input('accounts-table', 'selected_rows'),
+    State('accounts-table', 'data'),
+    prevent_initial_call=True,
+)
+def open_edit_account_modal(selected_rows, table_data):
+    if not selected_rows:
+        return dash.no_update, dash.no_update, dash.no_update, dash.no_update, dash.no_update, dash.no_update
+
+    row = table_data[selected_rows[0]]
+
+    return (
+        True,
+        row.get('id'),
+        row.get('name'),
+        row.get('type'),
+        row.get('starting_balance'),
+        row.get('currency'),
+    )
+
+
+@callback(
+    Output('edit-account-modal', 'is_open', allow_duplicate=True),
+    Output('accounts-refresh-store', 'data', allow_duplicate=True),
+    Input('update-account-button', 'n_clicks'),
+    State('edit-account-id', 'data'),
+    State('edit-account-name-input', 'value'),
+    State('edit-account-type-input', 'value'),
+    State('edit-account-balance-input', 'value'),
+    State('edit-account-currency-input', 'value'),
+    State('token-store', 'data'),
+    State('accounts-refresh-store', 'data'),
+    prevent_initial_call=True,
+)
+def update_account_cb(_, acc_id, name, acc_type, starting_balance, currency, token_data, refresh):
+    if not _ or not token_data or not acc_id:
+        return dash.no_update, dash.no_update
+
+    payload = {
+        'name': name,
+        'type': acc_type,
+        'starting_balance': starting_balance,
+        'currency': currency,
+    }
+    request_update_account(token_data['access_token'], acc_id, payload)
+    refresh_val = (refresh or {}).get('refresh', 0) + 1
+    return False, {'refresh': refresh_val}
+
+
+@callback(
+    Output('edit-account-modal', 'is_open', allow_duplicate=True),
+    Output('accounts-refresh-store', 'data', allow_duplicate=True),
+    Input('delete-account-button', 'n_clicks'),
+    State('edit-account-id', 'data'),
+    State('token-store', 'data'),
+    State('accounts-refresh-store', 'data'),
+    prevent_initial_call=True,
+)
+def delete_account_cb(n_clicks, acc_id, token_data, refresh):
+    if not n_clicks or not token_data or not acc_id:
+        return dash.no_update, dash.no_update
+
+    request_delete_account(token_data['access_token'], acc_id)
+    refresh_val = (refresh or {}).get('refresh', 0) + 1
+    return False, {'refresh': refresh_val}
+
+
+@callback(
+    Output('edit-account-modal', 'is_open', allow_duplicate=True),
+    Input('close-edit-account-modal', 'n_clicks'),
+    State('edit-account-modal', 'is_open'),
+    prevent_initial_call=True,
+)
+def close_edit_account_modal(n_clicks, is_open):
+    if n_clicks:
+        return False
+    return is_open

--- a/src/frontend/utils/tabs.py
+++ b/src/frontend/utils/tabs.py
@@ -8,5 +8,6 @@ class Tab(Enum):
     OVERVIEW = "Overview"
     MONTHLY_VIEW = "Monthly View"
     YEARLY_VIEW = "Yearly View"
+    ACCOUNTS = "Accounts"
     TRANSACTIONS = "Transactions"
     PROFILE = "Profile"


### PR DESCRIPTION
## Summary
- extend Tab enum with Accounts
- create add/edit account modals
- implement accounts tab with pagination and edit/delete functionality
- update navigation with add account button
- support account creation in dashboard
- expose account CRUD requests