### PR TITLE
Refactor tab styling into CSS

### DIFF
--- a/src/frontend/assets/tabs/common.css
+++ b/src/frontend/assets/tabs/common.css
@@ -1,0 +1,36 @@
+.tab-content {
+    background-color: var(--background-primary);
+    padding: 24px;
+    margin: 0;
+    min-height: 100%;
+    width: 100%;
+}
+
+.tab-heading {
+    color: var(--text-primary);
+    margin-bottom: 20px;
+}
+
+.card-title-sm {
+    color: var(--text-primary);
+    font-size: 16px;
+}
+
+.page-info {
+    align-self: center;
+    margin-left: 10px;
+}
+
+.no-margin { margin: 0 !important; }
+
+.border-income { border: 1px solid var(--income-color) !important; }
+.border-expense { border: 1px solid var(--expense-color) !important; }
+.border-savings { border: 1px solid var(--savings-color) !important; }
+.border-investment { border: 1px solid var(--investment-color) !important; }
+.border-accent { border: 1px solid var(--accent-primary) !important; }
+.loading-offset { margin-top: -1.5rem !important; }
+.flex-between { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+.flex-1 { flex: 1; }
+.loading-zero { margin-top: 0 !important; }
+.flex-center { display: flex; align-items: center; }
+.mt-20 { margin-top: 20px !important; }

--- a/src/frontend/pages/tabs/accounts.py
+++ b/src/frontend/pages/tabs/accounts.py
@@ -14,25 +14,17 @@ LIMIT = 50
 def create_accounts_tab():
     """Create the accounts tab content"""
 
-    content_style = {
-        'backgroundColor': COLORS['background_primary'],
-        'padding': '24px',
-        'margin': '0',
-        'minHeight': '100%',
-        'width': '100%'
-    }
-
     return html.Div(
         id='accounts-tab-content',
-        style=content_style,
+        className='tab-content',
         children=[
-            html.H2('Accounts', style={'color': COLORS['text_primary'], 'marginBottom': '20px'}),
+            html.H2('Accounts', className='tab-heading'),
             dcc.Store(id='accounts-offset-store', data={'offset': 0}),
             dcc.Store(id='accounts-refresh-store', data={'refresh': 0}),
             dbc.Row([
                 dbc.Col(dbc.Button('Previous', id='accounts-prev-btn', color='secondary', className='me-2'), width='auto'),
                 dbc.Col(dbc.Button('Next', id='accounts-next-btn', color='secondary'), width='auto'),
-                dbc.Col(html.Div(id='accounts-page-info', style={'alignSelf': 'center', 'marginLeft': '10px'}), width='auto')
+                dbc.Col(html.Div(id='accounts-page-info', className='page-info'), width='auto')
             ], className='mb-3'),
             dcc.Loading(
                 dash_table.DataTable(

--- a/src/frontend/pages/tabs/monthly_view.py
+++ b/src/frontend/pages/tabs/monthly_view.py
@@ -1,20 +1,9 @@
 from dash import html
-from utils.theme import COLORS, CARD_STYLE
 
 def create_monthly_view_tab():
     """Create the monthly view tab content"""
-    
-    content_style = {
-        'backgroundColor': COLORS['background_primary'],
-        'padding': '24px',
-        'margin': '0',
-        'minHeight': '100%',
-        'width': '100%'
-    }
-    
+
     return html.Div([
-        html.H1("Monthly View", style={
-            'color': COLORS['text_primary'],
-        }),
+        html.H1("Monthly View", className="tab-heading"),
         # Add your monthly view content here
-    ], style=content_style)
+    ], className="tab-content")

--- a/src/frontend/pages/tabs/overview.py
+++ b/src/frontend/pages/tabs/overview.py
@@ -1,6 +1,6 @@
 from dash import html, Input, Output, State, callback, dash_table, dcc
 import dash_bootstrap_components as dbc
-from utils.theme import COLORS, LOADING_STYLE
+from utils.theme import COLORS
 from helper.requests.overview_request import get_overview
 from utils.currency import CURRENCY_SYMBOLS
 
@@ -9,64 +9,57 @@ from utils.currency import CURRENCY_SYMBOLS
 def create_overview_tab():
     """Create the overview tab content"""
     
-    content_style = {
-        'backgroundColor': COLORS['background_primary'],
-        'padding': '24px',
-        'margin': '0',
-        'minHeight': '100%',
-        'width': '100%'
-    }
-    
     content = html.Div(
         id='overview-tab-content',
-        style=content_style,
+        className='tab-content',
         children=[
-            html.H2("Financial Overview", style={
-                'color': COLORS['text_primary'],
-                'marginBottom': '20px'
-            }),
+            html.H2("Financial Overview", className='tab-heading'),
             
             # Key Metrics Cards Row
             dbc.Row([
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Income", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Income", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="overview-income", children='', style={'color': COLORS['income_color'], 'margin': '0'})
-                            , style={**LOADING_STYLE, 'marginTop': '-1.5rem'})
+                                html.H3(id="overview-income", children='', className="income-color no-margin"),
+                                className="loading loading-offset"
+                            )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['income_color']}"})
+                    ], className='card border-income')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Expenses", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Expenses", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="overview-expenses", children='', style={'color': COLORS['expense_color'], 'margin': '0'})
-                            , style={**LOADING_STYLE, 'marginTop': '-1.5rem'})
+                                html.H3(id="overview-expenses", children='', className="expense-color no-margin"),
+                                className="loading loading-offset"
+                            )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['expense_color']}"})
+                    ], className='card border-expense')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Savings", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Savings", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="overview-savings", children='', style={'color': COLORS['savings_color'], 'margin': '0'})
-                            , style={**LOADING_STYLE, 'marginTop': '-1.5rem'})
+                                html.H3(id="overview-savings", children='', className="savings-color no-margin"),
+                                className="loading loading-offset"
+                            )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['savings_color']}"})
+                    ], className='card border-savings')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Investments", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Investments", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="overview-investments", children='', style={'color': COLORS['investment_color'], 'margin': '0'})
-                            , style={**LOADING_STYLE, 'marginTop': '-1.5rem'})
+                                html.H3(id="overview-investments", children='', className="investment-color no-margin"),
+                                className="loading loading-offset"
+                            )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['investment_color']}"})
+                    ], className='card border-investment')
                 ], width=3),
             ], className="mb-4"),
             
@@ -75,36 +68,36 @@ def create_overview_tab():
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Profit/Loss", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Profit/Loss", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="overview-profit", children='', style={'margin': '0'}),
-                                style={**LOADING_STYLE, 'marginTop': '-1.5rem'}
+                                html.H3(id="overview-profit", children='', className="no-margin"),
+                                className="loading loading-offset"
                             )
                         ])
-                    ], id="profit-card", style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['accent_primary']}"})
+                    ], id="profit-card", className='card border-accent')
                 ], width=6),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Cash Flow", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Cash Flow", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="overview-cashflow", children='', style={'margin': '0'}),
-                                style={**LOADING_STYLE, 'marginTop': '-1.5rem'}
+                                html.H3(id="overview-cashflow", children='', className="no-margin"),
+                                className="loading loading-offset"
                             )
                         ])
-                    ], id="cashflow-card", style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['accent_primary']}"})
+                    ], id="cashflow-card", className='card border-accent')
                 ], width=6),
             ], className="mb-4"),
             
             # Category Breakdown Table
             dbc.Card([
                 dbc.CardHeader([
-                    html.H4("Category Breakdown", className="mb-0", style={'color': COLORS['text_primary']})
+                    html.H4("Category Breakdown", className="mb-0 text-primary")
                 ]),
                 dbc.CardBody([
                     html.Div(id="overview-category-table", children='')
                 ])
-            ], style={'backgroundColor': COLORS['background_secondary']})
+            ], className='card')
         ]
     )
 
@@ -202,7 +195,7 @@ def update_overview_content(nav_data, token_store, user_settings):
                 ]
             )
         else:
-            category_table = html.P("No category data available", style={'color': COLORS['text_secondary']})
+            category_table = html.P("No category data available", className='text-secondary')
         
         return (
             format_currency(income),      # income

--- a/src/frontend/pages/tabs/profile.py
+++ b/src/frontend/pages/tabs/profile.py
@@ -1,6 +1,5 @@
 from dash import html, dcc, Input, State, Output, callback
 import dash_bootstrap_components as dbc
-from utils.theme import COLORS, CARD_STYLE, LOADING_STYLE
 from datetime import datetime
 from helper.requests.profile_request import request_profile_data
 from utils.currency import CURRENCY_OPTIONS
@@ -9,142 +8,131 @@ from utils.currency import CURRENCY_OPTIONS
 def create_profile_tab():
     """Create the profile tab content"""
     
-    content_style = {
-        'backgroundColor': COLORS['background_primary'],
-        'padding': '24px',
-        'margin': '0',
-        'minHeight': '100%',
-        'width': '100%'
-    }
-
     content = html.Div([
         html.Div([
-            html.H1("Profile Settings", style={
-                'color': COLORS['text_primary'],
-                'margin': '0',
-                'flex': '1'
-            })
-        ], style={
-            'display': 'flex',
-            'justifyContent': 'space-between',
-            'alignItems': 'center',
-            'marginBottom': '20px'
-        }),
+            html.H1("Profile Settings", className="tab-heading no-margin flex-1")
+        ], className="flex-between"),
         
         # Profile content with placeholder structure
         html.Div([
             # Basic Information Card
             dbc.Card([
-                dbc.CardHeader([
-                    html.H4("Basic Information", className="mb-0", style={'color': COLORS['text_primary']})
-                ]),
+                dbc.CardHeader(
+                    html.H4("Basic Information", className="mb-0 text-primary")
+                ),
                 dcc.Loading(
-                dbc.CardBody([
-                    dbc.Row([
-                        dbc.Col([
-                            html.Strong("Email:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-email", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
-                        dbc.Col([
-                            html.Strong("Role:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-role", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
+                    dbc.CardBody([
+                        dbc.Row([
+                            dbc.Col([
+                                html.Strong("Email:", className='text-primary'),
+                                html.P(id="profile-email", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                            dbc.Col([
+                                html.Strong("Role:", className='text-primary'),
+                                html.P(id="profile-role", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                        ]),
+                        dbc.Row([
+                            dbc.Col([
+                                html.Strong("Phone:", className='text-primary'),
+                                html.P(id="profile-phone", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                            dbc.Col([
+                                html.Strong("Currency:", className='text-primary'),
+                                dcc.Dropdown(
+                                    id="profile-currency",
+                                    options=[
+                                        {"label": html.Span(label), "value": value}
+                                        for label, value in CURRENCY_OPTIONS
+                                    ],
+                                    value="CZK",
+                                    clearable=False,
+                                    style={
+                                        'width': '220px',
+                                        "paddingLeft": '10px',
+                                    },
+                                    className="profile-currency-dropdown"
+                                )
+                            ], width=3, className='flex-center'),
+                        ])
                     ]),
-                    dbc.Row([
-                        dbc.Col([
-                            html.Strong("Phone:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-phone", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
-                        dbc.Col([
-                            html.Strong("Currency:", style={'color': COLORS['text_primary']}),
-                            dcc.Dropdown(
-                                id="profile-currency",
-                                options=[
-                                    {"label": html.Span(label), "value": value}
-                                    for label, value in CURRENCY_OPTIONS
-                                ],
-                                value="CZK",
-                                clearable=False,
-                                style={
-                                    'width': '220px',
-                                    "paddingLeft": '10px',
-                                },
-                                className="profile-currency-dropdown"
-                            )
-                        ], width=3, style={'display': 'flex', 'alignItems': 'center'}),
-                    ])
-                ]), style={**LOADING_STYLE, 'marginTop': '0rem'})
-            ], className="mb-3", style={'backgroundColor': COLORS['background_secondary']}),
+                    className="loading loading-zero"
+                )
+            ], className="card mb-3"),
             # Account Status Card
             dbc.Card([
                 dbc.CardHeader([
-                    html.H4("Account Status", className="mb-0", style={'color': COLORS['text_primary']})
+                    html.H4("Account Status", className="mb-0 text-primary")
                 ]),
                 dcc.Loading(
-                dbc.CardBody([
-                    dbc.Row([
-                        dbc.Col([
-                            html.Strong("Email Verified:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-email-verified", children=[
-                                dbc.Badge('', color="secondary", className="ms-2")
-                            ], className="mb-2")
-                        ], width=6),
-                        dbc.Col([
-                            html.Strong("Phone Verified:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-phone-verified", children=[
-                                dbc.Badge('', color="secondary", className="ms-2")
-                            ], className="mb-2")
-                        ], width=6),
-                    ]),
-                    dbc.Row([
-                        dbc.Col([
-                            html.Strong("Anonymous User:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-anonymous", children=[
-                                dbc.Badge('', color="secondary", className="ms-2")
-                            ], className="mb-2")
-                        ], width=6),
-                        dbc.Col([
-                            html.Strong("Provider:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-provider", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
-                    ])
-                ]), style={**LOADING_STYLE, 'marginTop': '0rem'})
-            ], className="mb-3", style={'backgroundColor': COLORS['background_secondary']}),
+                    dbc.CardBody([
+                        dbc.Row([
+                            dbc.Col([
+                                html.Strong("Email Verified:", className='text-primary'),
+                                html.P(id="profile-email-verified", children=[
+                                    dbc.Badge('', color="secondary", className="ms-2")
+                                ], className="mb-2")
+                            ], width=6),
+                            dbc.Col([
+                                html.Strong("Phone Verified:", className='text-primary'),
+                                html.P(id="profile-phone-verified", children=[
+                                    dbc.Badge('', color="secondary", className="ms-2")
+                                ], className="mb-2")
+                            ], width=6),
+                        ]),
+                        dbc.Row([
+                            dbc.Col([
+                                html.Strong("Anonymous User:", className='text-primary'),
+                                html.P(id="profile-anonymous", children=[
+                                    dbc.Badge('', color="secondary", className="ms-2")
+                                ], className="mb-2")
+                            ], width=6),
+                            dbc.Col([
+                                html.Strong("Provider:", className='text-primary'),
+                                html.P(id="profile-provider", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                        ])
+                    ],
+                ), className="loading loading-zero"
+                )
+            ], className="card mb-3"),
             
             # Account Timeline Card
             dbc.Card([
                 dbc.CardHeader([
-                    html.H4("Account Timeline", className="mb-0", style={'color': COLORS['text_primary']})
+                    html.H4("Account Timeline", className="mb-0 text-primary")
                 ]),
                 dcc.Loading(
-                dbc.CardBody([
-                    dbc.Row([
-                        dbc.Col([
-                            html.Strong("Account Created:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-created", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
-                        dbc.Col([
-                            html.Strong("Last Updated:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-updated", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
-                    ]),
-                    dbc.Row([
-                        dbc.Col([
-                            html.Strong("Last Sign In:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-signin", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
-                        dbc.Col([
-                            html.Strong("Email Confirmed:", style={'color': COLORS['text_primary']}),
-                            html.P(id="profile-email-confirmed", children='', className="mb-2", style={'color': COLORS['text_secondary']})
-                        ], width=6),
-                    ])
-                ]), style={**LOADING_STYLE, 'marginTop': '0rem'})
-            ], className="mb-3", style={'backgroundColor': COLORS['background_secondary']}),
+                    dbc.CardBody([
+                        dbc.Row([
+                            dbc.Col([
+                                html.Strong("Account Created:", className='text-primary'),
+                                html.P(id="profile-created", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                            dbc.Col([
+                                html.Strong("Last Updated:", className='text-primary'),
+                                html.P(id="profile-updated", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                        ]),
+                        dbc.Row([
+                            dbc.Col([
+                                html.Strong("Last Sign In:", className='text-primary'),
+                                html.P(id="profile-signin", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                            dbc.Col([
+                                html.Strong("Email Confirmed:", className='text-primary'),
+                                html.P(id="profile-email-confirmed", children='', className="mb-2 text-secondary")
+                            ], width=6),
+                        ])
+                    ],
+                ), className="loading loading-zero"
+                )
+            ], className="card mb-3"),
             
             # Account Actions Card
             dbc.Card([
                 dbc.CardHeader([
-                    html.H4("Account Actions", className="mb-0", style={'color': COLORS['text_primary']})
+                    html.H4("Account Actions", className="mb-0 text-primary")
                 ]),
                 dbc.CardBody([
                     dbc.Row([
@@ -173,9 +161,9 @@ def create_profile_tab():
                         ])
                     ])
                 ])
-            ], style={'backgroundColor': COLORS['background_secondary']})
+            ], className='card')
         ])
-    ], style=content_style)
+    ], className='tab-content')
 
     return content
 

--- a/src/frontend/pages/tabs/transactions.py
+++ b/src/frontend/pages/tabs/transactions.py
@@ -45,25 +45,17 @@ def _attach_names(items: list[dict], access_token: str) -> list[dict]:
 def create_transactions_tab():
     """Create the transactions tab content"""
 
-    content_style = {
-        'backgroundColor': COLORS['background_primary'],
-        'padding': '24px',
-        'margin': '0',
-        'minHeight': '100%',
-        'width': '100%'
-    }
-
     return html.Div(
         id='transactions-tab-content',
-        style=content_style,
+        className='tab-content',
         children=[
-            html.H2('Transactions', style={'color': COLORS['text_primary'], 'marginBottom': '20px'}),
+            html.H2('Transactions', className='tab-heading'),
             dcc.Store(id='transactions-offset-store', data={'offset': 0}),
             dcc.Store(id='transactions-refresh-store', data={'refresh': 0}),
             dbc.Row([
                 dbc.Col(dbc.Button('Previous', id='transactions-prev-btn', color='secondary', className='me-2'), width='auto'),
                 dbc.Col(dbc.Button('Next', id='transactions-next-btn', color='secondary'), width='auto'),
-                dbc.Col(html.Div(id='transactions-page-info', style={'alignSelf': 'center', 'marginLeft': '10px'}), width='auto')
+                dbc.Col(html.Div(id='transactions-page-info', className='page-info'), width='auto')
             ], className='mb-3'),
             dcc.Loading(
                 dash_table.DataTable(

--- a/src/frontend/pages/tabs/yearly_view.py
+++ b/src/frontend/pages/tabs/yearly_view.py
@@ -1,7 +1,7 @@
 from dash import html, dcc, Input, Output, State, callback
 import dash_bootstrap_components as dbc
 import plotly.graph_objects as go
-from utils.theme import COLORS, LOADING_STYLE
+from utils.theme import COLORS
 from helper.requests.yearly_analytics_request import get_yearly_analytics, get_emergency_fund_analysis
 from utils.currency import CURRENCY_SYMBOLS
 import datetime
@@ -10,29 +10,21 @@ import datetime
 def create_yearly_view_tab():
     """Create the yearly view tab content with comprehensive analytics"""
 
-    content_style = {
-        'backgroundColor': COLORS['background_primary'],
-        'padding': '24px',
-        'margin': '0',
-        'minHeight': '100%',
-        'width': '100%'
-    }
-
     current_year = datetime.datetime.now().year
     year_options = [{"label": str(year), "value": year} for year in range(current_year - 5, current_year + 2)]
 
     content = html.Div(
         id='yearly-view-tab-content',
-        style=content_style,
+        className='tab-content',
         children=[
             # Header with year selector
             html.Div([
                 html.H2(
                     "Yearly Financial Analytics",
-                    style={'color': COLORS['text_primary'], 'margin': '0', 'flex': '1'}
+                    className='tab-heading no-margin flex-1'
                 ),
                 html.Div([
-                    html.Label("Select Year:", style={'color': COLORS['text_primary'], 'marginRight': '10px'}),
+                    html.Label("Select Year:", className='text-primary', style={'marginRight': '10px'}),
                     dcc.Dropdown(
                         id='yearly-year-selector',
                         options=year_options,
@@ -40,13 +32,8 @@ def create_yearly_view_tab():
                         clearable=False,
                         style={'width': '120px', 'display': 'inline-block'}
                     )
-                ], style={'display': 'flex', 'alignItems': 'center'})
-            ], style={
-                'display': 'flex',
-                'justifyContent': 'space-between',
-                'alignItems': 'center',
-                'marginBottom': '24px'
-            }),
+                ], className='flex-center')
+            ], className='flex-between mb-24'),
             
             # Store for yearly data
             dcc.Store(id='yearly-analytics-store'),
@@ -57,46 +44,46 @@ def create_yearly_view_tab():
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Income", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Income", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-total-income", children='', style={'color': COLORS['income_color'], 'margin': '0'}),
-                                style={**LOADING_STYLE, 'marginTop': '-1.5rem'}
+                                html.H3(id="yearly-total-income", children='', className="income-color no-margin"),
+                                className="loading loading-offset"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['income_color']}"})
+                    ], className='card border-income')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Expenses", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Expenses", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-total-expenses", children='', style={'color': COLORS['expense_color'], 'margin': '0'}),
-                                style=LOADING_STYLE
+                                html.H3(id="yearly-total-expenses", children='', className="expense-color no-margin"),
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['expense_color']}"})
+                    ], className='card border-expense')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Savings", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Savings", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-total-savings", children='', style={'color': COLORS['savings_color'], 'margin': '0'}),
-                                style=LOADING_STYLE
+                                html.H3(id="yearly-total-savings", children='', className="savings-color no-margin"),
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['savings_color']}"})
+                    ], className='card border-savings')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Total Investments", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Total Investments", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-total-investments", children='', style={'color': COLORS['investment_color'], 'margin': '0'}),
-                                style=LOADING_STYLE
+                                html.H3(id="yearly-total-investments", children='', className="investment-color no-margin"),
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['investment_color']}"})
+                    ], className='card border-investment')
                 ], width=3),
             ], className="mb-4"),
             
@@ -105,46 +92,46 @@ def create_yearly_view_tab():
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Profit/Loss", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Profit/Loss", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-profit", children='', style={'margin': '0'}),
-                                style=LOADING_STYLE
+                                html.H3(id="yearly-profit", children='', className="no-margin"),
+                                className="loading"
                             )
                         ])
-                    ], id="yearly-profit-card", style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['accent_primary']}"})
+                    ], id="yearly-profit-card", className='card border-accent')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Net Cash Flow", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Net Cash Flow", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-net-flow", children='', style={'margin': '0'}),
-                                style=LOADING_STYLE
+                                html.H3(id="yearly-net-flow", children='', className="no-margin"),
+                                className="loading"
                             )
                         ])
-                    ], id="yearly-net-flow-card", style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['accent_primary']}"})
+                    ], id="yearly-net-flow-card", className='card border-accent')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Savings Rate", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Savings Rate", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-savings-rate", children='', style={'color': COLORS['savings_color'], 'margin': '0'}),
-                                style=LOADING_STYLE
+                                html.H3(id="yearly-savings-rate", children='', className="savings-color no-margin"),
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['savings_color']}"})
+                    ], className='card border-savings')
                 ], width=3),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardBody([
-                            html.H4("Investment Rate", className="card-title", style={'color': COLORS['text_primary'], 'fontSize': '16px'}),
+                            html.H4("Investment Rate", className="card-title card-title-sm"),
                             dcc.Loading(
-                                html.H3(id="yearly-investment-rate", children='', style={'color': COLORS['investment_color'], 'margin': '0'}),
-                                style=LOADING_STYLE
+                                html.H3(id="yearly-investment-rate", children='', className="investment-color no-margin"),
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary'], 'border': f"1px solid {COLORS['investment_color']}"})
+                    ], className='card border-investment')
                 ], width=3),
             ], className="mb-4"),
             
@@ -153,28 +140,28 @@ def create_yearly_view_tab():
                 dbc.Col([
                     dbc.Card([
                         dbc.CardHeader([
-                            html.H4("Monthly Income vs Expenses", className="mb-0", style={'color': COLORS['text_primary']})
+                            html.H4("Monthly Income vs Expenses", className="mb-0 text-primary")
                         ]),
                         dbc.CardBody([
                             dcc.Loading(
                                 dcc.Graph(id='yearly-income-expense-chart', config={'displayModeBar': False}),
-                                style=LOADING_STYLE
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary']})
+                    ], className='card')
                 ], width=6),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardHeader([
-                            html.H4("Core vs Fun Expenses", className="mb-0", style={'color': COLORS['text_primary']})
+                            html.H4("Core vs Fun Expenses", className="mb-0 text-primary")
                         ]),
                         dbc.CardBody([
                             dcc.Loading(
                                 dcc.Graph(id='yearly-expense-breakdown-chart', config={'displayModeBar': False}),
-                                style=LOADING_STYLE
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary']})
+                    ], className='card')
                 ], width=6),
             ], className="mb-4"),
             
@@ -183,57 +170,57 @@ def create_yearly_view_tab():
                 dbc.Col([
                     dbc.Card([
                         dbc.CardHeader([
-                            html.H4("Monthly Savings & Investments", className="mb-0", style={'color': COLORS['text_primary']})
+                            html.H4("Monthly Savings & Investments", className="mb-0 text-primary")
                         ]),
                         dbc.CardBody([
                             dcc.Loading(
                                 dcc.Graph(id='yearly-savings-investment-chart', config={'displayModeBar': False}),
-                                style=LOADING_STYLE
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary']})
+                    ], className='card')
                 ], width=6),
                 dbc.Col([
                     dbc.Card([
                         dbc.CardHeader([
-                            html.H4("Monthly Saving & Investing ratios", className="mb-0", style={'color': COLORS['text_primary']})
+                            html.H4("Monthly Saving & Investing ratios", className="mb-0 text-primary")
                         ]),
                         dbc.CardBody([
                             dcc.Loading(
                                 dcc.Graph(id='yearly-saving-investing-ratios-chart', config={'displayModeBar': False}),
-                                style=LOADING_STYLE
+                                className="loading"
                             )
                         ])
-                    ], style={'backgroundColor': COLORS['background_secondary']})
+                    ], className='card')
                 ], width=6),
             ], className="mb-4"),
             
             # Emergency Fund Analysis
             dbc.Card([
                 dbc.CardHeader([
-                    html.H4("Emergency Fund Analysis", className="mb-0", style={'color': COLORS['text_primary']})
+                    html.H4("Emergency Fund Analysis", className="mb-0 text-primary")
                 ]),
                 dbc.CardBody([
                     dcc.Loading([
                         dbc.Row([
                             dbc.Col([
-                                html.H5("3-Month Emergency Fund", style={'color': COLORS['text_primary']}),
-                                html.Div(id="emergency-fund-3-month", style={'marginBottom': '20px'})
+                                html.H5("3-Month Emergency Fund", className='text-primary'),
+                                html.Div(id="emergency-fund-3-month", className='mb-20')
                             ], width=6),
                             dbc.Col([
-                                html.H5("6-Month Emergency Fund", style={'color': COLORS['text_primary']}),
-                                html.Div(id="emergency-fund-6-month", style={'marginBottom': '20px'})
+                                html.H5("6-Month Emergency Fund", className='text-primary'),
+                                html.Div(id="emergency-fund-6-month", className='mb-20')
                             ], width=6),
                         ]),
                         dbc.Row([
                             dbc.Col([
-                                html.H5("Core Expenses Breakdown", style={'color': COLORS['text_primary'], 'marginTop': '20px'}),
+                                html.H5("Core Expenses Breakdown", className='text-primary mt-20'),
                                 html.Div(id="core-expenses-breakdown")
                             ], width=12)
                         ])
-                    ], style=LOADING_STYLE)
+                    ], className="loading")
                 ])
-            ], style={'backgroundColor': COLORS['background_secondary']})
+            ], className='card')
         ]
     )
 
@@ -455,9 +442,9 @@ def update_emergency_fund_analysis(emergency_data, user_settings):
     if not emergency_data or 'data' not in emergency_data:
         # Always return a string or placeholder, never no_update or None
         return (
-            html.P("No data", style={'color': COLORS['text_secondary']}),
-            html.P("No data", style={'color': COLORS['text_secondary']}),
-            html.P("No data", style={'color': COLORS['text_secondary']})
+            html.P("No data", className='text-secondary'),
+            html.P("No data", className='text-secondary'),
+            html.P("No data", className='text-secondary')
         )
     
     # Get currency symbol
@@ -473,14 +460,14 @@ def update_emergency_fund_analysis(emergency_data, user_settings):
     three_month_target = data.get('three_month_fund_target', 0)
     
     three_month_content = html.Div([
-        html.P(f"Target: {fmt(three_month_target)}", style={'color': COLORS['text_primary'], 'margin': '5px 0'}),
+        html.P(f"Target: {fmt(three_month_target)}", className='text-primary', style={'margin': '5px 0'}),
         ])
     
     # 6-month fund analysis
     six_month_target = data.get('six_month_fund_target', 0)
     
     six_month_content = html.Div([
-        html.P(f"Target: {fmt(six_month_target)}", style={'color': COLORS['text_primary'], 'margin': '5px 0'}),
+        html.P(f"Target: {fmt(six_month_target)}", className='text-primary', style={'margin': '5px 0'}),
     ])
     
     # Core expenses breakdown
@@ -493,18 +480,18 @@ def update_emergency_fund_analysis(emergency_data, user_settings):
             percentage = (amount / (avg_monthly * 12) * 100) if avg_monthly > 0 else 0
             breakdown_items.append(
                 html.Div([
-                    html.Span(category, style={'color': COLORS['text_primary']}),
-                    html.Span(f"{fmt(amount)} ({percentage:.1f}%)", 
-                             style={'color': COLORS['text_secondary'], 'float': 'right'})
+                    html.Span(category, className='text-primary'),
+                    html.Span(f"{fmt(amount)} ({percentage:.1f}%)",
+                             className='text-secondary', style={'float': 'right'})
                 ], style={'margin': '5px 0', 'padding': '5px', 'backgroundColor': COLORS['background_tertiary'], 'borderRadius': '4px'})
             )
         
         breakdown_content = html.Div([
-            html.P(f"Average Monthly Core Expenses: {fmt(avg_monthly)}", 
-                  style={'color': COLORS['text_primary'], 'fontWeight': 'bold', 'marginBottom': '15px'}),
+            html.P(f"Average Monthly Core Expenses: {fmt(avg_monthly)}",
+                  className='text-primary', style={'fontWeight': 'bold', 'marginBottom': '15px'}),
             html.Div(breakdown_items)
         ])
     else:
-        breakdown_content = html.P("No core expense data available", style={'color': COLORS['text_secondary']})
+        breakdown_content = html.P("No core expense data available", className='text-secondary')
     
     return three_month_content, six_month_content, breakdown_content


### PR DESCRIPTION
## Summary
- add shared tab styles in `assets/tabs/common.css`
- refactor monthly, accounts, transactions, overview, profile and yearly view tabs to use CSS classes
- fix profile tab syntax